### PR TITLE
Feature/issue#11/support for git tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@
 Build and CI platform for adsabs.
   * Builds docker images based on templates. Triggered by github webhooks
   * Pushes successfully build images to dockerhub with the commit hash as tag
-  
+ 
 # Development
+
+You can run unit tests in the following way:
+```bash
+nosetests mc/tests/unittests
+```
 
 A Vagrantfile and puppet manifest are available for development within a virtual machine. To use the vagrant VM defined here you will need to install *Vagrant* and *VirtualBox*. 
 

--- a/mc/config.py
+++ b/mc/config.py
@@ -1,6 +1,8 @@
 GITHUB_SIGNATURE_HEADER = 'X-Hub-Signature'
 GITHUB_SECRET = 'redacted'
 GITHUB_COMMIT_API = 'https://api.github.com/repos/adsabs/{repo}/git/commits/{hash}'
+GITHUB_TAG_FIND_API = 'https://api.github.com/repos/adsabs/{repo}/git/refs/tags/{tag}'
+GITHUB_TAG_GET_API = 'https://api.github.com/repos/adsabs/{repo}/git/tags/{hash}'
 AWS_REGION = 'us-east-1'
 AWS_ACCESS_KEY = 'redacted'
 AWS_SECRET_KEY = 'redacted'

--- a/mc/models.py
+++ b/mc/models.py
@@ -14,6 +14,7 @@ class Commit(db.Model):
     """
     id = Column(Integer, primary_key=True)
     commit_hash = Column(String, unique=True)
+    tag = Column(String, unique=True)
     message = Column(String)
     timestamp = Column(DateTime)
     author = Column(String)

--- a/mc/tests/stubdata/github_commit_payload.py
+++ b/mc/tests/stubdata/github_commit_payload.py
@@ -30,3 +30,35 @@ payload='''{
     }
   ]
 }'''
+
+payload_tag = '''{
+  "ref": "refs/tags/v1.0.0",
+  "url": "https://api.github.com/repos/adsabs/adsws/git/refs/tags/v1.0.0",
+  "object": {
+    "sha": "unnitest-tag-commit",
+    "type": "tag",
+    "url": "https://api.github.com/repos/adsabs/adsws/git/tags/d0e1b1f82ddd1f2c42afbe15f624b120db66fbb4"
+  }
+}'''
+
+payload_get_tag = '''{
+  "sha": "unnitest-tag-commit",
+  "url": "https://api.github.com/repos/adsabs/governor/git/tags/unnitest-tag-commit",
+  "tagger": {
+    "name": "adsabs",
+    "email": "adshelp@cfa.harvard.edu",
+    "date": "2015-08-19T14:52:49Z"
+  },
+  "object": {
+    "sha": "unittest-commit",
+    "type": "commit",
+    "url": "https://api.github.com/repos/adsabs/governor/git/commits/2a047ead58a3a87b46388ac67fe08c944c3230e0"
+  },
+  "tag": "v1.0.0",
+  "message": "First version release 1.0.0"
+}'''
+
+payload_tag_fail = '''{
+  "message": "Not Found",
+  "documentation_url": "https://developer.github.com/v3"
+}'''

--- a/mc/tests/stubdata/github_webhook_payload.py
+++ b/mc/tests/stubdata/github_webhook_payload.py
@@ -175,3 +175,153 @@ payload = """{
     "site_admin": false
   }
 }"""
+
+payload_tag = """{
+  "ref": "refs/tags/v1.0.0",
+  "before": "0000000000000000000000000000000000000000",
+  "after": "18d8724f9c8946e5e46c0901d81aa41b26341881",
+  "created": true,
+  "deleted": false,
+  "forced": true,
+  "base_ref": null,
+  "compare": "https://github.com/adsabs/governor/compare/v1.0.0",
+  "commits": [
+
+  ],
+  "head_commit": {
+    "id": "2a047ead58a3a87b46388ac67fe08c944c3230e0",
+    "distinct": true,
+    "message": "First commit.",
+    "timestamp": "2015-08-12T16:18:57-04:00",
+    "url": "https://github.com/adsabs/governor/commit/2a047ead58a3a87b46388ac67fe08c944c3230e0",
+    "author": {
+      "name": "adsabs",
+      "email": "ads@cfa.harvard.edu",
+      "username": "adsabs"
+    },
+    "committer": {
+      "name": "adsabs",
+      "email": "ads@cfa.harvard.edu",
+      "username": "adsabs"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "governor",
+      "governor.go"
+    ]
+  },
+  "repository": {
+    "id": 40021965,
+    "name": "governor",
+    "full_name": "adsabs/governor",
+    "owner": {
+      "name": "adsabs",
+      "email": "ads@cfa.harvard.edu"
+    },
+    "private": false,
+    "html_url": "https://github.com/adsabs/governor",
+    "description": " Golang code for retrieving and creating config files defined in a Consul instance",
+    "fork": false,
+    "url": "https://github.com/adsabs/governor",
+    "forks_url": "https://api.github.com/repos/adsabs/governor/forks",
+    "keys_url": "https://api.github.com/repos/adsabs/governor/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/adsabs/governor/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/adsabs/governor/teams",
+    "hooks_url": "https://api.github.com/repos/adsabs/governor/hooks",
+    "issue_events_url": "https://api.github.com/repos/adsabs/governor/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/adsabs/governor/events",
+    "assignees_url": "https://api.github.com/repos/adsabs/governor/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/adsabs/governor/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/adsabs/governor/tags",
+    "blobs_url": "https://api.github.com/repos/adsabs/governor/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/adsabs/governor/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/adsabs/governor/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/adsabs/governor/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/adsabs/governor/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/adsabs/governor/languages",
+    "stargazers_url": "https://api.github.com/repos/adsabs/governor/stargazers",
+    "contributors_url": "https://api.github.com/repos/adsabs/governor/contributors",
+    "subscribers_url": "https://api.github.com/repos/adsabs/governor/subscribers",
+    "subscription_url": "https://api.github.com/repos/adsabs/governor/subscription",
+    "commits_url": "https://api.github.com/repos/adsabs/governor/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/adsabs/governor/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/adsabs/governor/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/adsabs/governor/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/adsabs/governor/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/adsabs/governor/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/adsabs/governor/merges",
+    "archive_url": "https://api.github.com/repos/adsabs/governor/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/adsabs/governor/downloads",
+    "issues_url": "https://api.github.com/repos/adsabs/governor/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/adsabs/governor/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/adsabs/governor/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/adsabs/governor/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/adsabs/governor/labels{/name}",
+    "releases_url": "https://api.github.com/repos/adsabs/governor/releases{/id}",
+    "created_at": 1438371662,
+    "updated_at": "2015-07-31T19:44:06Z",
+    "pushed_at": 1439996014,
+    "git_url": "git://github.com/adsabs/governor.git",
+    "ssh_url": "git@github.com:adsabs/governor.git",
+    "clone_url": "https://github.com/adsabs/governor.git",
+    "svn_url": "https://github.com/adsabs/governor",
+    "homepage": null,
+    "size": 2940,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": "Go",
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master",
+    "organization": "adsabs"
+  },
+  "pusher": {
+    "name": "adsabs",
+    "email": "ads@cfa.harvard.edu"
+  },
+  "organization": {
+    "login": "adsabs",
+    "id": 1004839,
+    "url": "https://api.github.com/orgs/adsabs",
+    "repos_url": "https://api.github.com/orgs/adsabs/repos",
+    "events_url": "https://api.github.com/orgs/adsabs/events",
+    "members_url": "https://api.github.com/orgs/adsabs/members{/member}",
+    "public_members_url": "https://api.github.com/orgs/adsabs/public_members{/member}",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1004839?v=3",
+    "description": "Smithsonian/NASA Astrophysics Data System"
+  },
+  "sender": {
+    "login": "adsabs",
+    "id": 633540,
+    "avatar_url": "https://avatars.githubusercontent.com/u/633540?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/jonnybazookatone",
+    "html_url": "https://github.com/jonnybazookatone",
+    "followers_url": "https://api.github.com/users/jonnybazookatone/followers",
+    "following_url": "https://api.github.com/users/jonnybazookatone/following{/other_user}",
+    "gists_url": "https://api.github.com/users/jonnybazookatone/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/jonnybazookatone/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/jonnybazookatone/subscriptions",
+    "organizations_url": "https://api.github.com/users/jonnybazookatone/orgs",
+    "repos_url": "https://api.github.com/users/jonnybazookatone/repos",
+    "events_url": "https://api.github.com/users/jonnybazookatone/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/jonnybazookatone/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}"""

--- a/mc/tests/unittests/test_commands.py
+++ b/mc/tests/unittests/test_commands.py
@@ -137,7 +137,7 @@ class TestBuildDockerImage(TestCase):
     @httpretty.activate
     def test_run(self):
         """
-        manage.py build <repo> <commit> should create a new Commit and
+        manage.py build -r <repo> -c <commit> should create a new Commit and
         build_docker.delay() should be called
         """
         repo, commit = "unittest-repo", "unittest-hash"
@@ -167,29 +167,67 @@ class TestBuildDockerImage(TestCase):
     @httpretty.activate
     def test_run_tag(self):
         """
-        manage.py build <repo> <tag> should create a new Commit and
+        manage.py build -r <repo> -t <tag> should create a new Commit and
         build_docker.delay() should be called
         """
-        repo, tag = "unittest-repo", "unittest-tag"
+        repo, tag, commit = 'unittest-repo', 'unittest-tag', 'unittest-commit'
+
+        tag, tag_commit, no_tag = 'unittest-tag', 'unnitest-tag-commit', \
+                                  'no-tag'
+
+        httpretty.register_uri(
+            httpretty.GET,
+            self.app.config['GITHUB_TAG_FIND_API'].format(
+                repo=repo, tag=tag
+            ),
+            body=github_commit_payload.payload_tag,
+            content_type='application/json'
+        )
+
+        httpretty.register_uri(
+            httpretty.GET,
+            self.app.config['GITHUB_TAG_GET_API'].format(
+                repo=repo, hash=tag_commit
+            ),
+            body=github_commit_payload.payload_get_tag,
+            content_type='application/json'
+        )
+
+        httpretty.register_uri(
+            httpretty.GET,
+            self.app.config['GITHUB_TAG_FIND_API'].format(
+                repo=repo, tag=no_tag
+            ),
+            body=github_commit_payload.payload_tag_fail,
+            content_type='application/json'
+        )
 
         httpretty.register_uri(
             httpretty.GET,
             self.app.config['GITHUB_COMMIT_API'].format(
-                repo=repo, hash=tag
+                repo=repo, hash=commit
             ),
             body=github_commit_payload.payload,
-            content_type="application/json"
+            content_type='application/json'
         )
 
         with mock.patch('mc.manage.build_docker') as mocked:
-            BuildDockerImage().run(repo, tag, app=self.app)
+            BuildDockerImage().run(repo, tag=tag, app=self.app)
             c = db.session.query(Commit).filter_by(
-                repository=repo, commit_hash=tag
+                repository=repo, tag=tag
             ).one()
             self.assertIsNotNone(c)
             mocked.delay.assert_called_once_with(c.id)
-            BuildDockerImage().run(repo, tag, app=self.app)
+            BuildDockerImage().run(repo, tag=tag, app=self.app)
             c2 = db.session.query(Commit).filter_by(
-                repository=repo, commit_hash=tag
+                repository=repo, tag=tag
             ).one()
             self.assertEqual(c.id, c2.id)
+
+            c3 = db.session.query(Commit).filter_by(
+                repository=repo, commit_hash=commit
+            ).one()
+            self.assertEqual(c.id, c3.id)
+
+            with self.assertRaises(KeyError):
+                BuildDockerImage().run(repo, tag=no_tag, app=self.app)

--- a/mc/tests/unittests/test_webservices.py
+++ b/mc/tests/unittests/test_webservices.py
@@ -1,7 +1,9 @@
 """
 Test webservices
 """
+import mock
 from mc import app
+from mc.models import Commit, db
 from flask.ext.testing import TestCase
 from flask import url_for
 
@@ -19,6 +21,21 @@ class TestEndpoints(TestCase):
         app_.config['MC_LOGGING'] = {}
         return app_
 
+    def setUp(self):
+        """
+        setUp and tearDown are run at the start of each test; ensure
+        that a fresh database is used for each test.
+        """
+        db.create_all()
+
+    def tearDown(self):
+        """
+        setUp and tearDown are run at the start of each test; ensure
+        that a fresh database is used for each test.
+        """
+        db.session.remove()
+        db.drop_all()
+
     def test_githublistener_endpoint(self):
         """
         Test basic functionality of the GithubListener endpoint
@@ -28,3 +45,35 @@ class TestEndpoints(TestCase):
         self.assertStatus(r, 405)  # Method not allowed
         r = self.client.post(url)
         self.assertStatus(r, 400)  # No signature given
+
+    def test_githublistener_post_return(self):
+        """
+        Test the overall response of the GithubListener post endpoint
+        """
+
+        # Without tag
+        commit = Commit(
+            repository='git-repo',
+            commit_hash='git-hash'
+        )
+        with mock.patch('mc.views.GithubListener') as gh_mock, \
+                mock.patch('mc.tasks.build_docker') as bd_mock:
+
+            gh_mock.parse_github_payload.return_value = commit
+            bd_mock.delay.return_value = None
+
+            url = url_for('GithubListener'.lower())
+            r = self.client.post(url)
+        self.assertEqual(r.json['received'], 'git-repo@git-hash, tag:None')
+
+        # With tag
+        commit.tag = 'v1.0.0'
+        with mock.patch('mc.views.GithubListener') as gh_mock, \
+                mock.patch('mc.tasks.build_docker') as bd_mock:
+
+            gh_mock.parse_github_payload.return_value = commit
+            bd_mock.delay.return_value = None
+
+            url = url_for('GithubListener'.lower())
+            r = self.client.post(url)
+        self.assertEqual(r.json['received'], 'git-repo@git-hash, tag:v1.0.0')


### PR DESCRIPTION
- Updated the GithubListener so it can add tags to the database if they are available, otherwise it defaults to None. It also assumes that tags are unique in the workflow of the developers.
- Models include also the tag field if available.
- Upgraded the manage.py build command such that it now accepts the tag flag. If requested, it looks up the tag and the commit from github. It fails if github does not have this tag.
