### PR TITLE
Adding tag to the build name, otherwise it uses the commit hash which…

### DIFF
--- a/mc/builders.py
+++ b/mc/builders.py
@@ -85,7 +85,7 @@ class DockerImageBuilder(object):
         self.tag = "{}/{}:{}".format(
             namespace,
             self.repo,
-            self.commit.commit_hash
+            self.commit.tag if self.commit.tag else self.commit.commit_hash
         )
         self.files = []
         self.tarfile = None


### PR DESCRIPTION
… is not human readable.
