### PR TITLE
Tags added on model update

### DIFF
--- a/mc/manage.py
+++ b/mc/manage.py
@@ -89,6 +89,10 @@ class BuildDockerImage(Command):
                     commit_hash=commit_hash,
                     repository=repo
                 ).one()
+
+                if not c.tag and tag:
+                    c.tag = tag
+
             except NoResultFound:
                 c = Commit(
                     commit_hash=commit_hash,

--- a/mc/tests/unittests/test_commands.py
+++ b/mc/tests/unittests/test_commands.py
@@ -212,12 +212,20 @@ class TestBuildDockerImage(TestCase):
         )
 
         with mock.patch('mc.manage.build_docker') as mocked:
-            BuildDockerImage().run(repo, tag=tag, app=self.app)
+
+            BuildDockerImage().run(repo, commit_hash=commit, app=self.app)
             c = db.session.query(Commit).filter_by(
-                repository=repo, tag=tag
+                repository=repo, commit_hash=commit
             ).one()
             self.assertIsNotNone(c)
             mocked.delay.assert_called_once_with(c.id)
+
+            BuildDockerImage().run(repo, tag=tag, app=self.app)
+            c1 = db.session.query(Commit).filter_by(
+                repository=repo, tag=tag
+            ).one()
+            self.assertEqual(c.id, c1.id)
+
             BuildDockerImage().run(repo, tag=tag, app=self.app)
             c2 = db.session.query(Commit).filter_by(
                 repository=repo, tag=tag

--- a/mc/views.py
+++ b/mc/views.py
@@ -78,10 +78,17 @@ class GithubListener(Resource):
             raise UnknownRepoError("{}".format(repo))
 
         try:
-            return Commit.query.filter_by(
+            c = Commit.query.filter_by(
                 commit_hash=commit_hash,
                 repository=repo
             ).one()
+
+            if not c.tag and tag:
+                c.tag = tag
+                db.session.add(c)
+                db.session.commit()
+
+            return c
         except NoResultFound:
             return Commit(
                 commit_hash=commit_hash,


### PR DESCRIPTION
Fixed the problem that a tag would not be added to the model if the commit already existed. Tests also updated to test this works appropriately.
