### PR TITLE
Feature/aws 139/add consul provisioner

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
     *mc/templates/docker/etc/adsws/common.py.monkeypatch
     *mc/templates/docker/etc/gunicorn/gunicorn.conf.py
 
+[report]
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,4 +37,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     puppet.manifests_path = "manifests"
     puppet.manifest_file = "site.pp"
   end
+
+  config.vm.provision :docker do |docker|
+    docker.pull_images "adsabs/consul:v1.0.0"
+  end
+
 end

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,6 +1,6 @@
 # Some const. variables
 $path_var = '/usr/bin:/usr/sbin:/bin:/usr/local/sbin:/usr/sbin:/sbin'
-$build_packages = ['python', 'python-dev', 'python-pip', 'git']
+$build_packages = ['python', 'python-dev', 'python-pip', 'git', 'libpq-dev', 'ipython']
 $pip_requirements = '/vagrant/requirements.txt'
 
 # Update package list

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -20,16 +20,17 @@ package {$build_packages:
 exec {'upgrade_pip':
   command => 'pip install --upgrade pip',
   require => Package[$build_packages],
+  path => $path_var,
 }
 
 # Install all python dependencies for selenium and general software
 exec {'pip_install_modules':
-  command => 'pip install -r ${pip_requirements}',
+  command => 'pip install -r /vagrant/requirements.txt',
   logoutput => on_failure,
   path => $path_var,
   tries => 2,
   timeout => 1000, # This is only require for Scipy/Matplotlib - they take a while
-  require => Package['upgrade_pip'],
+  require => Exec['upgrade_pip'],
 }
 
 Exec['apt_update_1'] -> Package[$build_packages] -> Exec['upgrade_pip'] -> Exec['pip_install_modules']

--- a/mc/builders.py
+++ b/mc/builders.py
@@ -248,16 +248,18 @@ class DockerRunner(object):
     the container, then tearing down the container
     """
 
-    def __init__(self, image, name, **kwargs):
+    def __init__(self, image, name, command=None, **kwargs):
         """
         :param image: full name of the docker image to pull
         :param name: name of the container in `docker run --name`
+        :param command: command for the container in `docker run <> command`
         :param mem_limit: Memory limit to enforce on the container
         :param kwargs: keyword args to pass direclty to
             docker.utils.create_host_config
         """
         self.image = image
         self.name = name
+        self.command = command
         self.host_config = create_host_config(**kwargs)
 
         self.client = Client(version='auto')
@@ -281,6 +283,7 @@ class DockerRunner(object):
             image=self.image,
             host_config=self.host_config,
             name=self.name,
+            command=self.command
         )
         self.logger.debug("Created container {}".format(self.container['Id']))
 

--- a/mc/config.py
+++ b/mc/config.py
@@ -27,6 +27,9 @@ DEPENDENCIES = {
         'USERNAME': 'postgres',
         'PORT': 5432,
         'HOST': 'localhost',
+    },
+    'CONSUL': {
+        'PORT': 8500
     }
 }
 

--- a/mc/provisioners.py
+++ b/mc/provisioners.py
@@ -39,7 +39,6 @@ class ScriptProvisioner(object):
             scripts = list(self.scripts)
             while scripts:
                 script = scripts.pop()
-                print script
                 p = subprocess.Popen(script, shell=shell)
                 p.wait()
                 self.processes["{}".format(script)] = p
@@ -98,6 +97,7 @@ class PostgresProvisioner(ScriptProvisioner):
         )
 
         return cli
+
 
 class ConsulProvisioner(ScriptProvisioner):
     """

--- a/mc/provisioners.py
+++ b/mc/provisioners.py
@@ -15,6 +15,7 @@ class ScriptProvisioner(object):
     """
     Calls a script via subprocess.Popen
     """
+    template_dir = os.path.join(os.path.dirname(__file__), 'templates')
 
     def __init__(self, scripts, shell=False):
         self.scripts = scripts
@@ -38,6 +39,7 @@ class ScriptProvisioner(object):
             scripts = list(self.scripts)
             while scripts:
                 script = scripts.pop()
+                print script
                 p = subprocess.Popen(script, shell=shell)
                 p.wait()
                 self.processes["{}".format(script)] = p
@@ -97,8 +99,63 @@ class PostgresProvisioner(ScriptProvisioner):
 
         return cli
 
+class ConsulProvisioner(ScriptProvisioner):
+    """
+    Provision the consul cluster key-value store
+    """
 
+    name = 'consul'
 
+    def __init__(self, services):
 
+        self._KNOWN_SERVICES = self.known_services()
+        self.processes = OrderedDict()
+        self.shell = True
 
+        services = [services] if isinstance(services, basestring) else services
+        if set(services).difference(self._KNOWN_SERVICES):
+            raise UnknownServiceError(
+                "{}".format(
+                    set(services).difference(self._KNOWN_SERVICES)))
 
+        self.services = OrderedDict()
+        engine = create_jinja2()
+        template = engine.get_template('{}/base.consul.template'.format(self.name))
+        self.directory = os.path.dirname(template.filename)
+        for s in services:
+            self.services[s] = template.render(
+                service=s,
+                port=ConsulProvisioner.get_cli_params()
+            )
+        self.scripts = self.services.values()
+
+    @classmethod
+    def known_services(cls):
+        """
+        Services consul knows about
+        :return: list of services
+        """
+        template_dir = '{base}/{provisioner}'.format(
+            base=cls.template_dir,
+            provisioner=cls.name
+        )
+        return [_dir for _dir in os.listdir(template_dir)
+                if os.path.isdir(os.path.join(template_dir, _dir))]
+
+    @staticmethod
+    def get_cli_params():
+        """
+        finds the command line parameters necessary to pass to `psql`
+        :returns string containing psql-specifically formatted params
+        """
+        try:
+            config = current_app.config
+        except RuntimeError:  # Outside of application context
+            config = create_app().config
+        config = config['DEPENDENCIES']['CONSUL']
+
+        cli = "{port}".format(
+            port=config.get('PORT', 8500),
+        )
+
+        return cli

--- a/mc/provisioners.py
+++ b/mc/provisioners.py
@@ -125,7 +125,9 @@ class ConsulProvisioner(ScriptProvisioner):
         for s in services:
             self.services[s] = template.render(
                 service=s,
-                port=ConsulProvisioner.get_cli_params()
+                port=ConsulProvisioner.get_cli_params(),
+                db_host=ConsulProvisioner.get_db_params()['HOST'],
+                db_port=ConsulProvisioner.get_db_params()['PORT']
             )
         self.scripts = self.services.values()
 
@@ -159,3 +161,16 @@ class ConsulProvisioner(ScriptProvisioner):
         )
 
         return cli
+
+    @staticmethod
+    def get_db_params():
+        """
+        finds the parameters necessary to connect to the postgres instance.
+        :return: string uri of the postgres instance
+        """
+        try:
+            config = current_app.config
+        except RuntimeError:  # Outside of application context
+            config = create_app().config
+
+        return config['DEPENDENCIES']['POSTGRES']

--- a/mc/templates/consul/adsws/adsws.config.json
+++ b/mc/templates/consul/adsws/adsws.config.json
@@ -1,0 +1,1 @@
+{"DEBUG": false, "CACHE": false}

--- a/mc/templates/consul/adsws/adsws.config.json
+++ b/mc/templates/consul/adsws/adsws.config.json
@@ -1,1 +1,1 @@
-{"DEBUG": false, "CACHE": false}
+{"DEBUG": false, "CACHE": false, "SQL_ALCHEMY_BINDS": {"adsws": "postgresql://adsws:@DB_HOST:DB_PORT/adsws"}}

--- a/mc/templates/consul/base.consul.template
+++ b/mc/templates/consul/base.consul.template
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+/usr/bin/python -c "
+import json
+import consulate
+
+# Load configuration file from JSON
+with open('{{service}}/{{service}}.config.json') as json_file:
+    config = json.load(json_file)
+
+# Connect to consul
+consul = consulate.Consul(port={{port}})
+
+# Load key/values from the configuration into the consul key/value store
+for key, value in config.iteritems():
+    consul.kv[key] = value
+"

--- a/mc/templates/consul/base.consul.template
+++ b/mc/templates/consul/base.consul.template
@@ -8,7 +8,7 @@ def configure_database(value):
     if type(value) != basestring or not 'DB_HOST' in value:
         return value
 
-    value = value.replace('DB_HOST', '{{db_host}}').replace('DB_PORT', {{db_port}}))
+    value = value.replace('DB_HOST', '{{db_host}}').replace('DB_PORT', {{db_port}})
     return value
 
 # Load configuration file from JSON
@@ -22,27 +22,3 @@ consul = consulate.Consul(port={{port}})
 for key, value in config.iteritems():
     consul.kv[key] = configure_database(value)
 "
-
-#!/bin/bash
-
-/usr/bin/python -c "
-import json
-import consulate
-
-def configure_database(value):
-    if type(value) != basestring or not 'DB_HOST' in value:
-        return value
-
-    value = value.replace('DB_HOST', 'localhost').replace('DB_PORT', 5432)
-    return value
-
-# Load configuration file from JSON
-with open('adsws/adsws.config.json') as json_file:
-    config = json.load(json_file)
-
-# Connect to consul
-consul = consulate.Consul(port=32779)
-
-# Load key/values from the configuration into the consul key/value store
-for key, value in config.iteritems():
-    consul.kv[key] = configure_database(value)

--- a/mc/templates/consul/base.consul.template
+++ b/mc/templates/consul/base.consul.template
@@ -4,6 +4,13 @@
 import json
 import consulate
 
+def configure_database(value):
+    if type(value) != basestring or not 'DB_HOST' in value:
+        return value
+
+    value = value.replace('DB_HOST', '{{db_host}}').replace('DB_PORT', {{db_port}}))
+    return value
+
 # Load configuration file from JSON
 with open('{{service}}/{{service}}.config.json') as json_file:
     config = json.load(json_file)
@@ -13,5 +20,29 @@ consul = consulate.Consul(port={{port}})
 
 # Load key/values from the configuration into the consul key/value store
 for key, value in config.iteritems():
-    consul.kv[key] = value
+    consul.kv[key] = configure_database(value)
 "
+
+#!/bin/bash
+
+/usr/bin/python -c "
+import json
+import consulate
+
+def configure_database(value):
+    if type(value) != basestring or not 'DB_HOST' in value:
+        return value
+
+    value = value.replace('DB_HOST', 'localhost').replace('DB_PORT', 5432)
+    return value
+
+# Load configuration file from JSON
+with open('adsws/adsws.config.json') as json_file:
+    config = json.load(json_file)
+
+# Connect to consul
+consul = consulate.Consul(port=32779)
+
+# Load key/values from the configuration into the consul key/value store
+for key, value in config.iteritems():
+    consul.kv[key] = configure_database(value)

--- a/mc/tests/livetests/test_provisioners.py
+++ b/mc/tests/livetests/test_provisioners.py
@@ -1,7 +1,7 @@
 """
 Test provisioners.py
 """
-from mc.provisioners import PostgresProvisioner
+from mc.provisioners import PostgresProvisioner, ConsulProvisioner
 from mc.builders import DockerRunner
 from mc.app import create_app
 
@@ -9,7 +9,74 @@ from werkzeug.security import gen_salt
 from sqlalchemy import create_engine
 import time
 import unittest
+import requests
+import consulate
 
+class TestConsulProvisioner(unittest.TestCase):
+    """
+    Test the ConsulProvisioner. Use the Docker builder to create the key/value
+    store
+    """
+
+    def setUp(self):
+        """
+        Starts a consul node for all the tests
+        """
+        self.name = 'livetest-consul-{}'.format(gen_salt(5))
+        self.builder = DockerRunner(
+            image='adsabs/consul:v1.0.0',
+            name=self.name,
+            mem_limit="50m",
+            port_bindings={8500: None},
+            command=['-server', '-bootstrap']
+        )
+        self.builder.start()
+        self.port = self.builder.client.port(
+            self.builder.container['Id'],
+            8500
+        )[0]['HostPort']
+
+        # Let consul start
+        time.sleep(5)
+
+    def tearDown(self):
+        """
+        Tears down the consul node used by the tests
+        """
+        self.builder.teardown()
+
+    def test_provisioning_consul(self):
+        """
+        Checks that consul is started correctly via docker
+        """
+        response = requests.get('http://localhost:{}'
+                                .format(self.port))
+        self.assertEqual(
+            response.status_code,
+            200,
+            msg='Consul service is non-responsive: {}'.format(response.text)
+        )
+
+    def _provision(self, service):
+        """
+        Run the provision for a given service
+        """
+        app = create_app()
+        app.config['DEPENDENCIES']['CONSUL']['PORT'] = self.port
+        with app.app_context():
+            ConsulProvisioner(service)()
+
+    def test_provisioning_adsws(self):
+        """
+        First run the provisioner and then we can check that some configuration
+        values have been correctly set in the key/value store
+        """
+
+        self._provision('adsws')
+
+        consul = consulate.Consul(port=self.port)
+        self.assertIn('DEBUG', consul.kv.keys())
+        self.assertEqual("false", consul.kv.get('DEBUG'))
 
 class TestPostgresProvisioner(unittest.TestCase):
     """

--- a/mc/tests/livetests/test_provisioners.py
+++ b/mc/tests/livetests/test_provisioners.py
@@ -43,9 +43,9 @@ class TestConsulProvisioner(unittest.TestCase):
         """
         Tears down the consul node used by the tests
         """
-        self.builder.teardown()
+        # self.builder.teardown()
 
-    def test_provisioning_consul(self):
+    def test_running_consul(self):
         """
         Checks that consul is started correctly via docker
         """
@@ -66,7 +66,7 @@ class TestConsulProvisioner(unittest.TestCase):
         with app.app_context():
             ConsulProvisioner(service)()
 
-    def test_provisioning_adsws(self):
+    def test_provisioning_adsws_service(self):
         """
         First run the provisioner and then we can check that some configuration
         values have been correctly set in the key/value store

--- a/mc/tests/unittests/test_builders.py
+++ b/mc/tests/unittests/test_builders.py
@@ -165,7 +165,8 @@ class TestDockerRunner(unittest.TestCase):
         self.instance.create_container.assert_called_with(
             host_config={'NetworkMode': 'host', "Memory": 104857600},
             name='redis',
-            image='redis'
+            image='redis',
+            command=None
         )
         self.instance.pull.assert_called_with('redis')
 

--- a/mc/tests/unittests/test_provisioners.py
+++ b/mc/tests/unittests/test_provisioners.py
@@ -3,7 +3,8 @@ Test provisioners.py
 """
 import unittest
 from flask import current_app
-from mc.provisioners import ScriptProvisioner, PostgresProvisioner
+from mc.provisioners import ScriptProvisioner, PostgresProvisioner, \
+    ConsulProvisioner
 from mc.exceptions import UnknownServiceError
 from mc.app import create_app
 
@@ -75,3 +76,64 @@ class TestPostgresProvisioner(unittest.TestCase):
             with self.assertRaises(KeyError):
                 del current_app.config['DEPENDENCIES']['POSTGRES']
                 PostgresProvisioner.get_cli_params()
+
+class TestConsulProvisioner(unittest.TestCase):
+    """
+    Test that consul is provisioned correctly
+    """
+
+    def test_unknown_service(self):
+        """
+        Consul should not provision config values for unknown services.
+        """
+        with self.assertRaisesRegexp(UnknownServiceError, 'unknown-service'):
+            ConsulProvisioner('unknown-service')
+
+    def test_discovers_services_from_templates(self):
+        """
+        Provisioner should auto-discover which services it knows about.
+        """
+        known_services = ['adsws']
+        discovered_services = ConsulProvisioner.known_services()
+        self.assertEqual(known_services, discovered_services)
+
+    def test_templates(self):
+        """
+        Test that the templates are rendered after init on a known service;
+        The attribute self.services should be a dict with
+        key,value = service, template
+        the attribute directory should point to the base template directory
+        """
+        services = ['adsws']
+        P = ConsulProvisioner(services)
+        self.assertIsInstance(P.services, dict)
+        self.assertListEqual(services, P.services.keys())
+        for s in services:
+            self.assertIsInstance(P.services[s], basestring)
+            print P.services
+            self.assertIn(
+                s,
+                P.services[s],
+                msg="{} not in {}".format(s, P.services[s])
+            )
+        ends_with = 'templates/consul'
+        self.assertTrue(
+            P.directory.endswith(ends_with),
+            msg='{} does not endwith {}'.format(P.directory, ends_with)
+        )
+
+    def test_get_cli_params(self):
+        """
+        This @staticmethod should return a string.
+        The function should work both with and without an application context
+        """
+        cli = ConsulProvisioner.get_cli_params()
+        self.assertIsInstance(cli, basestring)
+
+        with create_app().app_context():
+            self.assertEqual(cli, ConsulProvisioner.get_cli_params())
+            # Delete the requires config value to see if the method tries to
+            # access it. Expect KeyError
+            with self.assertRaises(KeyError):
+                del current_app.config['DEPENDENCIES']['CONSUL']
+                ConsulProvisioner.get_cli_params()

--- a/mc/tests/unittests/test_provisioners.py
+++ b/mc/tests/unittests/test_provisioners.py
@@ -137,3 +137,21 @@ class TestConsulProvisioner(unittest.TestCase):
             with self.assertRaises(KeyError):
                 del current_app.config['DEPENDENCIES']['CONSUL']
                 ConsulProvisioner.get_cli_params()
+
+    def test_get_database_params(self):
+        """
+        This @statmicmethod should return a string.
+        The function should work both with and without and application context.
+        It retreives the relevant parameters from postgres, for consul.
+        """
+
+        db = ConsulProvisioner.get_db_params()
+        self.assertIsInstance(db, basestring)
+
+        with create_app().app_context():
+            self.assertEqual(db, ConsulProvisioner.get_db_params())
+            # Delete the requires config value to see if the method tries to
+            # access it. Expect KeyError
+            with self.assertRaises(KeyError):
+                del current_app.config['DEPENDENCIES']['POSTGRES']
+                ConsulProvisioner.get_db_params()

--- a/mc/tests/unittests/test_provisioners.py
+++ b/mc/tests/unittests/test_provisioners.py
@@ -77,6 +77,7 @@ class TestPostgresProvisioner(unittest.TestCase):
                 del current_app.config['DEPENDENCIES']['POSTGRES']
                 PostgresProvisioner.get_cli_params()
 
+
 class TestConsulProvisioner(unittest.TestCase):
     """
     Test that consul is provisioned correctly
@@ -110,7 +111,6 @@ class TestConsulProvisioner(unittest.TestCase):
         self.assertListEqual(services, P.services.keys())
         for s in services:
             self.assertIsInstance(P.services[s], basestring)
-            print P.services
             self.assertIn(
                 s,
                 P.services[s],
@@ -140,13 +140,13 @@ class TestConsulProvisioner(unittest.TestCase):
 
     def test_get_database_params(self):
         """
-        This @statmicmethod should return a string.
+        This @statmicmethod should return a dictionary.
         The function should work both with and without and application context.
         It retreives the relevant parameters from postgres, for consul.
         """
 
         db = ConsulProvisioner.get_db_params()
-        self.assertIsInstance(db, basestring)
+        self.assertIsInstance(db, dict)
 
         with create_app().app_context():
             self.assertEqual(db, ConsulProvisioner.get_db_params())

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ nose
 boto3
 httpretty
 coveralls
+consulate==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ boto3
 httpretty
 coveralls
 consulate==0.6.0
+psycopg2==2.6.1


### PR DESCRIPTION
AWS-139 Add Consul Provisioner

Consul provisioner with unit and live tests have been included.

Provisioning of files requires the consul provisioner be aware of the postgres instance, as it has to fill the relevant ports in the service configuration files. This will require some thing on how to take care of whether or not we know one of the provisioned services is alive or not.

Not all the config files have been included for each service yet, but will be added in the next PR. The functionality, however, exists.

Relevant changes were made in the Vagrantfile, and how it installs and pulls some images with docker on provisioning.
