### PR TITLE
command to run task on ECS

### DIFF
--- a/mc/manage.py
+++ b/mc/manage.py
@@ -14,7 +14,7 @@ from flask.ext.migrate import Migrate, MigrateCommand
 from flask import current_app
 from mc.models import db, Build, Commit
 from mc.app import create_app
-from mc.tasks import build_docker, register_task_revision, update_service
+from mc.tasks import build_docker, register_task_revision, update_service, run_task
 from mc.builders import ECSBuilder
 from sqlalchemy import or_
 from sqlalchemy.orm.exc import NoResultFound
@@ -199,7 +199,26 @@ class UpdateService(Command):
                            taskDefinition=taskDefinition,
             )
 
+class RunTask(Command):
+    """
+    Calls tasks.run_task to run a specific task on an ECS cluster
+    """
 
+    option_list = (
+        Option('--cluster', '-c', dest='cluster'),
+        Option('--desiredCount', dest='desiredCount', type=int),
+        Option('--taskDefinition', '-t', dest='taskDefinition'),
+    )
+
+    def run(self, cluster, desiredCount, taskDefinition, app=app):
+        with app.app_context():
+            run_task(cluster=cluster,
+                           desiredCount=desiredCount,
+                           taskDefinition=taskDefinition,
+            )
+
+
+manager.add_command('run_task', RunTask)
 manager.add_command('update_service', UpdateService)
 manager.add_command('register_task_def', RegisterTaskRevision)
 manager.add_command('db', MigrateCommand)

--- a/mc/tasks.py
+++ b/mc/tasks.py
@@ -49,6 +49,21 @@ def update_service(cluster, service, desiredCount, taskDefinition):
         taskDefinition=taskDefinition
     )
 
+@celery.task()
+def run_task(cluster, desiredCount, taskDefinition):
+    """
+    Thin wrapper around boto3 ecs.update_service;
+    # http://boto3.readthedocs.org/en/latest/reference/services/ecs.html#ECS.Client.run_task
+    :param cluster: The short name or full Amazon Resource Name (ARN) of the cluster that your service is running on. If you do not specify a cluster, the default cluster is assumed.
+    :param desiredCount: The number of instantiations of the task that you would like to place and keep running in your service.
+    :param taskDefinition: The family and revision (family:revision ) or full Amazon Resource Name (ARN) of the task definition that you want to run in your service. If a revision is not specified, the latest ACTIVE revision is used. If you modify the task definition with UpdateService , Amazon ECS spawns a task with the new version of the task definition and then stops an old task after the new version is running.
+    """
+    client = get_boto_session().client('ecs')
+    client.run_task(
+        cluster=cluster,
+        desiredCount=desiredCount,
+        taskDefinition=taskDefinition
+    )
 
 @celery.task()
 def make_test_environment(test_id, config=None):

--- a/mc/tests/unittests/test_commands.py
+++ b/mc/tests/unittests/test_commands.py
@@ -6,7 +6,7 @@ from flask.ext.testing import TestCase
 from mc.app import create_app
 from mc.tests.stubdata import github_commit_payload
 from mc.manage import BuildDockerImage, MakeDockerrunTemplate, \
-    RegisterTaskRevision, UpdateService
+    RegisterTaskRevision, UpdateService, RunTask
 from mc.models import db, Commit, Build
 import mock
 import httpretty
@@ -53,6 +53,25 @@ class TestUpdateService(TestCase):
         UpdateService().run(app=self.app, **kwargs)
         mocked.assert_called_with(**kwargs)
 
+class TestRunTask(TestCase):
+    """
+    Test the manage.py run_task command
+    """
+    def create_app(self):
+        return create_app()
+
+    @mock.patch('mc.manage.run_task')
+    def test_run(self, mocked):
+        """
+        manage.py run_task <args> should be passed to tasks.run_task
+        """
+        kwargs = dict(
+            cluster="unittest-cluster",
+            desiredCount=1,
+            taskDefinition="unittest-taskdefinition",
+        )
+        RunTask().run(app=self.app, **kwargs)
+        mocked.assert_called_with(**kwargs)
 
 class TestMakeDockerrunTemplate(TestCase):
     """

--- a/mc/tests/unittests/test_tasks.py
+++ b/mc/tests/unittests/test_tasks.py
@@ -5,7 +5,7 @@ from flask.ext.testing import TestCase
 from mock import patch
 from mc import app
 from mc.models import db, Commit, Build
-from mc.tasks import register_task_revision, build_docker, update_service
+from mc.tasks import register_task_revision, build_docker, update_service, run_task
 import datetime
 
 
@@ -69,6 +69,29 @@ class TestUpdateService(TestCase):
         session.client.assert_called_with('ecs')
         client.update_service.assert_called_with(**kwargs)
 
+class TestRunTask(TestCase):
+    """
+    Test the run task
+    """
+    def create_app(self):
+        return app.create_app()
+
+    @patch('mc.tasks.get_boto_session')
+    def test_run_task(self, Session):
+        """
+        the run_task task should pass call the boto3 task after
+        establishing a session
+        """
+        session = Session.return_value
+        client = session.client.return_value
+        kwargs = dict(
+            cluster="unittest-cluster",
+            desiredCount=1,
+            taskDefinition='{"valid": "json"}',
+        )
+        run_task(**kwargs)
+        session.client.assert_called_with('ecs')
+        client.run_task.assert_called_with(**kwargs)
 
 class TestDockerBuildTask(TestCase):
     """


### PR DESCRIPTION
The Run Task functionality is needed to be able to run Task Definitions that have a desired status of STOP, i.e. do a specific thing (like making a backup) and then exit.
