### PR TITLE
Closes AWS-197

### DIFF
--- a/mc/config.py
+++ b/mc/config.py
@@ -35,11 +35,15 @@ DEPENDENCIES = {
     },
     'REDIS': {
         'PORT': 6379,
-        'IMAGE': 'redis:2.8.19'
+        'IMAGE': 'redis:2.8.21'
     },
     'GUNICORN': {
         'PORT': 80
     },
+    'SOLR': {
+        'PORT': 8983,
+        'IMAGE': 'adsabs/montysolr:v48.1.0.3'
+    }
 }
 
 MC_LOGGING = {

--- a/mc/tasks.py
+++ b/mc/tasks.py
@@ -78,13 +78,17 @@ def start_test_environment(test_id='livetest', config={}):
             "image": "redis:2.8.9",
         },
         {
-            "name": "consul",
-            "image": "adsabs/consul:v1.0.0",
-        },
-        {
             "name": "postgres",
             "image": "postgres:9.3",
         },
+        {
+            "name": "solr",
+            "image": "adsabs/montysolr:v48.1.0.3"
+        },
+        {
+            "name": "consul",
+            "image": "adsabs/consul:v1.0.0",
+        }
     ])
 
     for d in dependencies:

--- a/mc/templates/solr/base.solr.template
+++ b/mc/templates/solr/base.solr.template
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+article_content=`cat {{service}}/{{service}}.json`
+curl {{host}}:{{port}}/solr/update/json?commit=true -H 'Content-type: application/json' -d "$article_content"

--- a/mc/templates/solr/recommender/recommender.json
+++ b/mc/templates/solr/recommender/recommender.json
@@ -1,0 +1,1 @@
+[{"year": "2010", "id": "111", "bibcode": "2010MNRAS.409.1719J", "keyword_norm": ["stars magnetic fields", "-", "-", "-"], "citation": ["2010MNRAS.409.1719J"], "title": ["title"], "first_author": "Smith, John", "reference": ["2010MNRAS.409.1719J"], "citation_count": 1, "pubdate": "2010-12-00"}]

--- a/mc/tests/livetests/test_builders.py
+++ b/mc/tests/livetests/test_builders.py
@@ -6,7 +6,7 @@ import unittest
 
 from mc import config
 from mc.builders import DockerRunner, ConsulDockerRunner, PostgresDockerRunner, \
-    RedisDockerRunner, GunicornDockerRunner
+    RedisDockerRunner, GunicornDockerRunner, SolrDockerRunner
 from werkzeug.security import gen_salt
 
 
@@ -66,6 +66,38 @@ class TestDockerRunner(unittest.TestCase):
             filters={'status': 'running'}
         )]
         self.assertIn(self.builder.container['Id'], running)
+
+
+class TestBaseDockerRunner(unittest.TestCase):
+
+    def setUp(self):
+        self.name = 'livetest-service-{}'.format(gen_salt(5))
+        self.builder = DockerRunner(
+            name=self.name,
+        )
+
+    def tearDown(self):
+        """
+        teardown the containers
+        """
+        try:
+            self.builder.teardown()
+        except:
+            pass
+
+    def helper_test_is_ready(self):
+        """
+        Check if the instance is ready
+        """
+
+        self.builder.start()
+
+        self.assertTrue(self.builder.running)
+        self.assertTrue(self.builder.ready)
+
+        self.builder.teardown()
+        self.assertFalse(self.builder.ready)
+        self.assertFalse(self.builder.running)
 
 
 class TestRedisDockerRunner(unittest.TestCase):
@@ -209,3 +241,21 @@ class TestGunicornDockerRunner(unittest.TestCase):
         self.builder.teardown()
         self.assertFalse(self.builder.ready)
         self.assertFalse(self.builder.running)
+
+
+class TestSolrDockerRunner(TestBaseDockerRunner):
+    """
+    Test the docker runner for the Solr service
+    """
+
+    def setUp(self):
+        self.name = 'livetest-solr-{}'.format(gen_salt(5))
+        self.builder = SolrDockerRunner(
+            name=self.name,
+        )
+
+    def test_is_ready(self):
+        """
+        Check if the instance is ready
+        """
+        self.helper_test_is_ready()

--- a/mc/tests/livetests/test_provisioners.py
+++ b/mc/tests/livetests/test_provisioners.py
@@ -1,9 +1,9 @@
 """
 Test provisioners.py
 """
-from mc.provisioners import PostgresProvisioner, ConsulProvisioner, TestProvisioner
+from mc.provisioners import PostgresProvisioner, ConsulProvisioner, TestProvisioner, SolrProvisioner
 from mc.builders import DockerRunner, ConsulDockerRunner, PostgresDockerRunner, \
-    GunicornDockerRunner
+    GunicornDockerRunner, SolrDockerRunner
 from werkzeug.security import gen_salt
 from sqlalchemy import create_engine
 
@@ -215,3 +215,76 @@ class TestTestProvisioner(unittest.TestCase):
         )
         self.assertIn(api_url, test_provisioner.scripts[0])
 
+
+class TestSolrProvisioner(unittest.TestCase):
+    """
+    Test the SolrProvisioner. Use the Docker builder to create the index
+    """
+
+    def setUp(self):
+        """
+        Starts a solr node for all the tests
+        """
+        self.name = 'livetest-solr-{}'.format(gen_salt(5))
+        self.builder = SolrDockerRunner(
+            name=self.name,
+        )
+
+        self.builder.start()
+        self.port = self.builder.client.port(
+            self.builder.container['Id'],
+            8983
+        )[0]['HostPort']
+
+    def tearDown(self):
+        """
+        Tears down the consul node used by the tests
+        """
+        self.builder.teardown()
+
+    def _provision(self, service):
+        """
+        Run the provision for a given service
+        """
+        SolrProvisioner(service, container=self.builder)()
+
+    def test_provisioning_recommender_service(self):
+        """
+        First run the provisioner and then we can check that the documents have been added to the solr index
+        """
+        self._provision('recommender')
+
+        # Obtain what we expect to find
+        config_file = '{}/{}/recommender/recommender.json'.format(
+            SolrProvisioner.template_dir,
+            SolrProvisioner.name,
+        )
+
+        with open(config_file) as json_file:
+            config = json.load(json_file)
+
+        # Compare with consul
+        for document in config:
+            response = requests.get('http://{host}:{port}/solr/query?q=bibcode:{bibcode}'.format(
+                host='localhost',
+                port=self.port,
+                bibcode=document['bibcode'])
+            )
+            self.assertEqual(
+                200,
+                response.status_code,
+                msg='We expect a 200 response but got: {}, {}'.format(response.status_code, response.json())
+            )
+
+            actual_document = response.json()['response']['docs'][0]
+            for key in document:
+                self.assertIn(key, document.keys())
+                self.assertEqual(
+                    document[key],
+                    actual_document[key],
+                    msg='Key {} mismatch: expected {} != actual {}'.format(
+                        key,
+                        document[key],
+                        actual_document[key]
+                    )
+                )

--- a/mc/tests/livetests/test_tasks.py
+++ b/mc/tests/livetests/test_tasks.py
@@ -3,6 +3,7 @@ Test builders
 """
 
 import redis
+import requests
 import unittest
 
 from mc.tasks import start_test_environment, stop_test_environment, run_test_in_environment
@@ -39,6 +40,11 @@ class TestTestEnvironment(unittest.TestCase):
                     "name": "postgres",
                     "image": DEPENDENCIES['POSTGRES']['IMAGE'],
                     "callback": None,
+                },
+                {
+                    "name": "solr",
+                    "image": DEPENDENCIES['SOLR']['IMAGE'],
+                    "callback": None
                 }
             ],
             'services': [
@@ -145,6 +151,18 @@ class TestTestEnvironment(unittest.TestCase):
             engine.connect()
         except OperationalError as e:
             self.fail('Postgresql database has not started: {}'.format(e))
+
+        # Check solr is running
+        solr_info = self.helper_get_container_values('solr', 8983)
+        response = requests.get('http://{host}:{port}'.format(
+                host=solr_info['host'],
+                port=solr_info['port']
+            )
+        )
+        self.assertEqual(
+            response.status_code,
+            404
+        )
 
     def test_stop_test_environment_task(self):
         """

--- a/mc/tests/unittests/test_tasks.py
+++ b/mc/tests/unittests/test_tasks.py
@@ -17,6 +17,7 @@ class TestTestEnvironment(TestCase):
     def create_app(self):
         return app.create_app()
 
+    @patch('mc.builders.SolrDockerRunner')
     @patch('mc.builders.GunicornDockerRunner')
     @patch('mc.builders.PostgresDockerRunner')
     @patch('mc.builders.ConsulDockerRunner')
@@ -25,7 +26,8 @@ class TestTestEnvironment(TestCase):
                                   mocked_redis_runner,
                                   mocked_consul_runner,
                                   mocked_postgres_runner,
-                                  mocked_gunicorn_runner
+                                  mocked_gunicorn_runner,
+                                  mocked_solr_runner
                                   ):
         """
         Tests that the containers relevant for the test environment are started
@@ -46,50 +48,48 @@ class TestTestEnvironment(TestCase):
                 "image": "redis:2.8.9",
             },
             {
-                "name": "consul",
-                "image": "adsabs/consul:v1.0.0",
-            },
-            {
                 "name": "postgres",
                 "image": "postgres:9.3",
+            },
+            {
+                "name": "solr",
+                "image": "adsabs/montysolr:v48.1.0.3"
+            },
+            {
+                "name": "consul",
+                "image": "adsabs/consul:v1.0.0",
             },
         ])
 
         instance_gunicorn_runner = mocked_gunicorn_runner.return_value
-        instance_gunicorn_runner.start.return_value = None
-        instance_gunicorn_runner.provision.return_value = None
-
         instance_redis_runner = mocked_redis_runner.return_value
-        instance_redis_runner.start.return_value = None
-        instance_redis_runner.provision.return_value = None
-
         instance_consul_runner = mocked_consul_runner.return_value
-        instance_consul_runner.start.return_value = None
-        instance_consul_runner.provision.return_value = None
-
         instance_postgres_runner = mocked_postgres_runner.return_value
-        instance_postgres_runner.start.return_value = None
-        instance_postgres_runner.provision.return_value = None
+        instance_solr_runner = mocked_solr_runner.return_value
+
+        instance_list = [
+            instance_gunicorn_runner,
+            instance_redis_runner,
+            instance_consul_runner,
+            instance_postgres_runner,
+            instance_solr_runner
+        ]
+
+        for instance in instance_list:
+            instance.start.return_value = None
+            instance.provision.return_value = None
 
         start_test_environment(test_id=None, config=config)
 
-        self.assertTrue(instance_redis_runner.start.called)
-        self.assertTrue(instance_consul_runner.start.called)
-        self.assertTrue(instance_postgres_runner.start.called)
-        self.assertTrue(instance_gunicorn_runner.start.called)
+        for instance in instance_list:
 
-        instance_redis_runner.provision.has_calls(
-            [call(callback=s['name']) for s in services]
-        )
-        instance_consul_runner.provision.has_calls(
-            [call(callback=s['name']) for s in services]
-        )
-        instance_postgres_runner.provision.has_calls(
-            [call(callback=s['name']) for s in services]
-        )
-        instance_gunicorn_runner.provision.has_calls(
-            [call(callback=s['name']) for s in services]
-        )
+            self.assertTrue(
+                instance.start.called,
+                msg='Instance {} was not called'.format(instance)
+            )
+            instance.provision.has_calls(
+                [call(callback=s['name']) for s in services]
+            )
 
     @patch('mc.tasks.Client')
     def test_containers_are_stopped(self, mocked):


### PR DESCRIPTION
Added a Solr builder that builds a single node of MontySolr.

Added a Solr provisioner that can ingest select records required by each service.

Tests for unit tests and live tests included.
